### PR TITLE
feat: Update Maven artifact publishing config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,16 +46,19 @@ publishing {
 			artifact bootJar
 		}
 	}
-	repositories {
-		maven {
-			credentials {
-				username nexusLogin
-				password nexusPassword
-			}
-			url "${nexusMavenRepositoryUrl}"
-                        allowInsecureProtocol = true
-		}
-	}
+    repositories {
+        maven {
+            credentials {
+                username = System.getenv('CI_USERNAME') ?: project.findProperty('nexusLogin') ?: 'defaultLogin'
+                password = System.getenv('CI_PASSWORD') ?: project.findProperty('nexusPassword') ?: 'defaultPassword'
+            }
+            def defaultRepoUrl = 'http://nexus:8081/repository/edp-maven-snapshots'
+            def releasesRepoUrl = project.findProperty('releasesRepoUrl') ?: defaultRepoUrl
+            def snapshotsRepoUrl = project.findProperty('snapshotsRepoUrl') ?: defaultRepoUrl
+            url = version.contains('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            allowInsecureProtocol = true
+        }
+    }
 }
 
 repositories {  


### PR DESCRIPTION
- Updated credentials config to dynamically use environment variables (`CI_USERNAME`, `CI_PASSWORD`), with fallback to project properties (`nexusLogin`, `nexusPassword`).

- Introduced `defaultRepoUrl` as fallback for snapshot and release repository URLs, ensuring a default publishing destination.

- Implemented logic to dynamically determine repository URL based on project version. If version contains 'SNAPSHOT', publishes to `snapshotsRepoUrl`; otherwise, to `releasesRepoUrl`.

Related: https://github.com/epam/edp-tekton/issues/132